### PR TITLE
Revert release-please-action v5 → v4 (fixes broken Release workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,14 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      # Pinned to v4: v5 introduced stricter conventional-commits parsing that
+      # rejects Dependabot's grouped-update commit format
+      # (`chore(deps)(deps-dev): ...` — double-paren scope). Several such commits
+      # exist in main's history. v4 still works (Node 20 runtime; deprecation
+      # warning on 2026-06-02 cutover, removed fall 2026). Revisit once stale
+      # problematic commits roll off the release window or v5 grows a backwards-
+      # compat parsing flag.
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json


### PR DESCRIPTION
## Problem

The recent v4→v5 bump (#50) broke the Release workflow on every push to main:

```
❯ error message: Error: unexpected token '(' at 1:12, valid tokens [!, :]
```

release-please v5 introduced stricter conventional-commits parsing that rejects Dependabot's grouped-update format (`chore(deps)(deps-dev): bump the development-dependencies group with 2 updates`). The double-paren scope was tolerated in v4 but rejects parsing in v5. Several such commits exist in this repo's main history.

## Fix

Revert to v4. Trade-off: v4 is Node 20 runtime, so it'll show a deprecation warning when the GitHub Actions runner cutover happens on **2026-06-02**, but it stays functional until Node 20 is removed in fall 2026.

## Followup (separate PR, not done here)

Update `.github/dependabot.yml` to drop `include: 'scope'` from the npm ecosystem so future grouped-update commits become `chore(deps): bump the development-dependencies group …` (single scope). After the problematic historical commits age out of the release window, we can re-attempt v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)