### PR TITLE
docs: bump Node prerequisite v20+ to v22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Figma plugin for generating realistic iMessage chat interfaces using AI. Creat
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) v20+
+- [Node.js](https://nodejs.org) v22+
 - [Figma desktop app](https://figma.com/downloads/)
 - [Anthropic API key](https://docs.anthropic.com/en/api/overview)
 - [Apple SF Pro typeface](https://developer.apple.com/fonts/)


### PR DESCRIPTION
Quick miss-fix from the Node 24 actions migration sweep. CI was bumped to Node 22 but README's prerequisite still said v20+. Updating to match what CI actually tests against. Node 18 has been EOL since April 2025 and 20 is approaching EOL April 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)