### PR TITLE
fix: unblock production build broken by @anthropic-ai/sdk node: imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Run TypeScript type check
         run: npx tsc --noEmit --skipLibCheck
 
+      - name: Build plugin
+        run: npm run build
+
       - name: Run tests with coverage
         run: npm run test:ci

--- a/webpack-configs/webpack.common.js
+++ b/webpack-configs/webpack.common.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const { DefinePlugin } = require('webpack');
+const { DefinePlugin, IgnorePlugin } = require('webpack');
 
 const paths = require('./paths.js');
 
@@ -42,6 +42,13 @@ module.exports = (env, argv) => ({
   },
   plugins: [
     new CleanWebpackPlugin(),
+    // The @anthropic-ai/sdk pulls in Node-only code that this Figma plugin never
+    // runs: the worker `agent-toolset` (bash/fs/edit tools) and lazy `node:fs`/
+    // `node:path` credential-file helpers. Both are reached only via dynamic
+    // imports behind unused code paths (the plugin just streams the messages API
+    // with a direct apiKey), so ignoring them stops webpack from following those
+    // imports into `node:` builtins it can't resolve for the browser sandbox.
+    new IgnorePlugin({ resourceRegExp: /agent-toolset|^node:/ }),
     new CaseSensitivePathsPlugin(),
     new ForkTsCheckerWebpackPlugin(),
     new DefinePlugin({


### PR DESCRIPTION
## Problem

`npm run build` (the production webpack build) currently fails on `main`:

```
ERROR in node:util
UnhandledSchemeError: Reading from "node:util" is not handled by plugins (Unhandled scheme).
ERROR in node:path
UnhandledSchemeError: Reading from "node:path" is not handled by plugins (Unhandled scheme).
```

A Dependabot bump pulled in a newer `@anthropic-ai/sdk` that ships:
- a **Node-only agent toolset** (`tools/agent-toolset/*` — bash/fs/edit tools), and
- **lazy credential-file helpers** (`lib/credentials/types.mjs`) that `await import('node:fs' | 'node:path')`.

Both are reached only through dynamic `import()`s behind code paths this plugin never executes — it just streams the messages API with a direct API key. But webpack statically follows dynamic imports at build time, parses those modules, hits their `node:*` builtins, and fails because the Figma sandbox targets the browser.

This went unnoticed because **CI never ran the build** — it lints, type-checks, and tests, but those don't exercise webpack.

## Fix

1. **`webpack.common.js`** — `IgnorePlugin({ resourceRegExp: /agent-toolset|^node:/ })` drops the dead Node-only subtrees so webpack stops following them into `node:` builtins. No emitted bundle references `node:` afterward, and no stray async chunk is produced (important, since the UI is inlined into a single `ui.html`).
2. **`ci.yml`** — add a `Build plugin` step after the type check so a broken bundle fails CI instead of slipping through green.

## Verification

- `npm run build` succeeds; emits `dist/plugin.js` + `dist/ui.html`.
- `grep -c 'require("node:'` on both emitted files → `0`.
- `fork-ts-checker` type-check passes during the build.
- The plugin only calls `anthropic.messages.create()`, so the ignored toolset/credential-file paths are genuinely dead code at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
