### PR TITLE
fix(test): polyfill TextEncoder/TextDecoder for jsdom

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,11 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
 import '@testing-library/jest-dom';
+
+// jsdom omits TextEncoder/TextDecoder, which @anthropic-ai/sdk constructs at
+// import time (lib/middleware.ts), so importing it blows up without these.
+(globalThis as any).TextEncoder ??= TextEncoder;
+(globalThis as any).TextDecoder ??= TextDecoder;
 
 // Extend global window interface
 declare global {


### PR DESCRIPTION
Unblocks #85 (`chore(deps): bump the production-dependencies group across 1 directory with 9 updates`).

## Root cause

`@anthropic-ai/sdk` `0.112.3` (up from `0.102.0`) instantiates a `TextEncoder` at **module scope**:

```
node_modules/@anthropic-ai/sdk/src/lib/middleware.ts:31
const encoder = new TextEncoder();
```

That line runs on import. Jests `jsdom` environment does not expose `TextEncoder`/`TextDecoder` as globals, so every suite whose import graph reaches `src/services/api.ts` throws before running a test:

```
FAIL src/services/__tests__/api.test.ts
  ● Test suite failed to run
    ReferenceError: TextEncoder is not defined
    > 1 | import Anthropic from "@anthropic-ai/sdk";
      at Object.<anonymous> (node_modules/@anthropic-ai/sdk/src/lib/middleware.ts:31:17)
      at Object.require (src/services/api.ts:2:1)
```

The confusing part is how it surfaces: the suites fail to **load**, so no assertion fails. `npm run test:ci` reports `Tests: 59 passed, 59 total` and still exits 1 — because the three unloadable suites are scored at 0% coverage and trip their `coverageThreshold` entries for `api.ts`, `chat-generation.ts` and `use-chat-generation.ts`.

## Fix

Assign the `node:util` implementations onto `globalThis` in `src/test/setup.ts`, using `??=` so any environment that already provides them is left alone.

## Verification

Ran the full `ci.yml` job locally on both dependency sets.

| | before | after |
|---|---|---|
| merge-base (sdk 0.102.0) | 7/7 suites, 88 tests | 7/7 suites, 88 tests |
| #85 branch (sdk 0.112.3) | **3 suites failed to run, 59 tests** | 7/7 suites, 88 tests |

On this branch (main + fix), every CI step exits 0: `style:write`, `lint:md`, `lint:fix`, `tsc --noEmit --skipLibCheck`, `build`, `test:ci`.

Once this lands, #85 needs a rebase to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CiHDtyZ29awB74m9TCk6Gp