### PR TITLE
fix(release): use plain version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,6 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      # Pinned to v4: v5 introduced stricter conventional-commits parsing that
-      # rejects Dependabot's grouped-update commit format
-      # (`chore(deps)(deps-dev): ...` — double-paren scope). Several such commits
-      # exist in main's history. v4 still works (Node 20 runtime; deprecation
-      # warning on 2026-06-02 cutover, removed fall 2026). Revisit once stale
-      # problematic commits roll off the release window or v5 grows a backwards-
-      # compat parsing flag.
       - uses: googleapis/release-please-action@v5
         id: release
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,111 +1,100 @@
 # Changelog
 
-## [1.3.0](https://github.com/pdugan20/figma-chat-builder/compare/imessage-chat-builder-v1.2.0...imessage-chat-builder-v1.3.0) (2026-07-21)
-
+## [1.3.0](https://github.com/pdugan20/figma-chat-builder/compare/v1.2.0...v1.3.0) (2026-07-21)
 
 ### Features
 
-* **api:** improve prompt engineering and fix parameter threading ([33f83ba](https://github.com/pdugan20/figma-chat-builder/commit/33f83bac25b82d74237b4835b1373840070d3136))
-* **deps:** upgrade to React 19 and testing-library 16 ([fbd524b](https://github.com/pdugan20/figma-chat-builder/commit/fbd524bd0363ba9e8c733bc6415f61b3d6d26469))
-* **deps:** upgrade to React 19 and testing-library 16 ([19d5754](https://github.com/pdugan20/figma-chat-builder/commit/19d5754c1a7a0515d94bc18a750dbb299b8f1560))
-* upgrade to Claude Sonnet 4.6 and add automated release pipeline ([2405136](https://github.com/pdugan20/figma-chat-builder/commit/24051365b4855b32e31e869fbab803a729feb390))
-
+- **api:** improve prompt engineering and fix parameter threading ([33f83ba](https://github.com/pdugan20/figma-chat-builder/commit/33f83bac25b82d74237b4835b1373840070d3136))
+- **deps:** upgrade to React 19 and testing-library 16 ([fbd524b](https://github.com/pdugan20/figma-chat-builder/commit/fbd524bd0363ba9e8c733bc6415f61b3d6d26469))
+- **deps:** upgrade to React 19 and testing-library 16 ([19d5754](https://github.com/pdugan20/figma-chat-builder/commit/19d5754c1a7a0515d94bc18a750dbb299b8f1560))
+- upgrade to Claude Sonnet 4.6 and add automated release pipeline ([2405136](https://github.com/pdugan20/figma-chat-builder/commit/24051365b4855b32e31e869fbab803a729feb390))
 
 ### Bug Fixes
 
-* add spacing between Learn more link and Add key button ([689d148](https://github.com/pdugan20/figma-chat-builder/commit/689d148ea9c0c9823b426687da52beb02c46a002))
-* resolve API response parsing and restore loading overlay ([08a9ec2](https://github.com/pdugan20/figma-chat-builder/commit/08a9ec2b813f96a110ca1e1fed5fc7844ef604f1))
-* resolve double ellipsis, error handling mismatch, and env flag injection ([7193ffd](https://github.com/pdugan20/figma-chat-builder/commit/7193ffd1fc2df5ef21a7cb525aa38f0005234df3))
-* **test:** polyfill TextEncoder/TextDecoder for jsdom ([#88](https://github.com/pdugan20/figma-chat-builder/issues/88)) ([9c8185f](https://github.com/pdugan20/figma-chat-builder/commit/9c8185f9767f530429dce33170c2c59de99f483d))
-* unblock production build broken by @anthropic-ai/sdk node: imports ([#81](https://github.com/pdugan20/figma-chat-builder/issues/81)) ([b1dc5ff](https://github.com/pdugan20/figma-chat-builder/commit/b1dc5ff7e2b6103173af1e0f69cae6c0bddbbf58))
-
-
-### Refactoring
-
-* **hooks:** refactor use-chat-generation to use services (Sprint 5) ([301af9f](https://github.com/pdugan20/figma-chat-builder/commit/301af9f555cfb103eca34bd3a6cab47be49bf5ae))
-* **lint:** migrate to ESLint 9 flat config ([3c74303](https://github.com/pdugan20/figma-chat-builder/commit/3c74303d79b78e2ac952ce6db8f2db267068cf48))
-* **lint:** migrate to ESLint 9 flat config ([e8d2a3b](https://github.com/pdugan20/figma-chat-builder/commit/e8d2a3bec479b2f7b4baad8e526f02559853d3bc))
-* remove dead code, unused deps, and reorganize project structure ([7119f16](https://github.com/pdugan20/figma-chat-builder/commit/7119f16184c4a5f39f3859e046e0cacf710c203a))
-* replace hardcoded dev flags with build-time env injection ([9498a62](https://github.com/pdugan20/figma-chat-builder/commit/9498a62deeb1ca10e5e649eeeb628844325b87af))
-* **services:** create APIService (Sprint 3) ([68c28ac](https://github.com/pdugan20/figma-chat-builder/commit/68c28acf09d55b1682470a38353d070323b1f164))
-* **services:** create ChatGenerationService (Sprint 4) ([317a41e](https://github.com/pdugan20/figma-chat-builder/commit/317a41e1503813954ca409da965f7af969a03864))
-* **services:** create PluginMessengerService and context (Sprint 2) ([f3291a1](https://github.com/pdugan20/figma-chat-builder/commit/f3291a1470892fe899d9319207a042741033781b))
-* **services:** create ValidationService and LoadingStateManager (Sprint 1) ([65a55b1](https://github.com/pdugan20/figma-chat-builder/commit/65a55b18a97063efe065bf54747cc30defd2aec3))
-
-
-### Documentation
-
-* bump Node prerequisite v20+ to v22+ ([#60](https://github.com/pdugan20/figma-chat-builder/issues/60)) ([66796b6](https://github.com/pdugan20/figma-chat-builder/commit/66796b6cddf73e6aba5512ee84acc0a119b06bd1))
-* clean up README - remove test coverage details and simplify title ([b937d98](https://github.com/pdugan20/figma-chat-builder/commit/b937d98f0fdadfab4a421f214f1771885dc3930a))
-* consolidate documentation and fix inaccuracies ([#33](https://github.com/pdugan20/figma-chat-builder/issues/33)) ([63ba850](https://github.com/pdugan20/figma-chat-builder/commit/63ba850a402d59ad80d300ebd0be7dd6ad79599b))
-* drop tech stack section ([7f46e55](https://github.com/pdugan20/figma-chat-builder/commit/7f46e558a237ec7da81701a30b9d04a9f4788f37))
-* enhance documentation with badges and contribution guidelines ([a69cd4a](https://github.com/pdugan20/figma-chat-builder/commit/a69cd4af085697e009d416b886dd268c424d6182))
-* finalize dependency upgrade tracker ([9b4223a](https://github.com/pdugan20/figma-chat-builder/commit/9b4223a0ede660c73a54fdff81457f7b20e187ce))
-* finalize dependency upgrade tracker ([0a7c1f9](https://github.com/pdugan20/figma-chat-builder/commit/0a7c1f9690feb69bbcbcdefa41d92067cc028db0))
-* fold Features into intro prose ([#61](https://github.com/pdugan20/figma-chat-builder/issues/61)) ([a95ccdb](https://github.com/pdugan20/figma-chat-builder/commit/a95ccdb1991a87b04e0c18a2c69db7e085d38229))
-* remove extra license section from README ([c50bf97](https://github.com/pdugan20/figma-chat-builder/commit/c50bf97d525976e06c4ba1725e1c0f51498420a7))
-* rename repo to figma-chat-builder, title 'Chat Builder Figma Plugin' ([0b1c17e](https://github.com/pdugan20/figma-chat-builder/commit/0b1c17e199acfed40c50090bbd03997da469fded))
-* reorganize docs folder and add dependency upgrade tracker ([8eba182](https://github.com/pdugan20/figma-chat-builder/commit/8eba182a176990e44e3ced4a46cc424f554ee128))
-* replace end-to-end flow prose with mermaid architecture diagram ([aabbdf0](https://github.com/pdugan20/figma-chat-builder/commit/aabbdf0a9906efb0e662e4831048f793aff223a8))
-* restore clean concise README ([c6a747c](https://github.com/pdugan20/figma-chat-builder/commit/c6a747c4f8278524bfdb2a1cdec74e5db4f040f7))
-* title README 'iMessage Chat Builder for Figma' ([98c6c62](https://github.com/pdugan20/figma-chat-builder/commit/98c6c627c4227712aac8c3f70b8466642f1005d6))
-* trim README badges to CI, Release, Figma Community, License ([4caa534](https://github.com/pdugan20/figma-chat-builder/commit/4caa5340a1b5db24b3606a0d9a81ed07f0d308ab))
-* update README badges, versions, and doc links ([c02b702](https://github.com/pdugan20/figma-chat-builder/commit/c02b70230038cbbc15788b8b3b53f6dbb1238be0))
-
-## [1.2.0](https://github.com/pdugan20/chat-builder-plugin/compare/imessage-chat-builder-v1.1.0...imessage-chat-builder-v1.2.0) (2026-03-05)
-
-
-### Features
-
-* **api:** improve prompt engineering and fix parameter threading ([33f83ba](https://github.com/pdugan20/chat-builder-plugin/commit/33f83bac25b82d74237b4835b1373840070d3136))
-* **deps:** upgrade to React 19 and testing-library 16 ([fbd524b](https://github.com/pdugan20/chat-builder-plugin/commit/fbd524bd0363ba9e8c733bc6415f61b3d6d26469))
-* **deps:** upgrade to React 19 and testing-library 16 ([19d5754](https://github.com/pdugan20/chat-builder-plugin/commit/19d5754c1a7a0515d94bc18a750dbb299b8f1560))
-
+- add spacing between Learn more link and Add key button ([689d148](https://github.com/pdugan20/figma-chat-builder/commit/689d148ea9c0c9823b426687da52beb02c46a002))
+- resolve API response parsing and restore loading overlay ([08a9ec2](https://github.com/pdugan20/figma-chat-builder/commit/08a9ec2b813f96a110ca1e1fed5fc7844ef604f1))
+- resolve double ellipsis, error handling mismatch, and env flag injection ([7193ffd](https://github.com/pdugan20/figma-chat-builder/commit/7193ffd1fc2df5ef21a7cb525aa38f0005234df3))
+- **test:** polyfill TextEncoder/TextDecoder for jsdom ([#88](https://github.com/pdugan20/figma-chat-builder/issues/88)) ([9c8185f](https://github.com/pdugan20/figma-chat-builder/commit/9c8185f9767f530429dce33170c2c59de99f483d))
+- unblock production build broken by @anthropic-ai/sdk node: imports ([#81](https://github.com/pdugan20/figma-chat-builder/issues/81)) ([b1dc5ff](https://github.com/pdugan20/figma-chat-builder/commit/b1dc5ff7e2b6103173af1e0f69cae6c0bddbbf58))
 
 ### Refactoring
 
-* **lint:** migrate to ESLint 9 flat config ([3c74303](https://github.com/pdugan20/chat-builder-plugin/commit/3c74303d79b78e2ac952ce6db8f2db267068cf48))
-* **lint:** migrate to ESLint 9 flat config ([e8d2a3b](https://github.com/pdugan20/chat-builder-plugin/commit/e8d2a3bec479b2f7b4baad8e526f02559853d3bc))
-
+- **hooks:** refactor use-chat-generation to use services (Sprint 5) ([301af9f](https://github.com/pdugan20/figma-chat-builder/commit/301af9f555cfb103eca34bd3a6cab47be49bf5ae))
+- **lint:** migrate to ESLint 9 flat config ([3c74303](https://github.com/pdugan20/figma-chat-builder/commit/3c74303d79b78e2ac952ce6db8f2db267068cf48))
+- **lint:** migrate to ESLint 9 flat config ([e8d2a3b](https://github.com/pdugan20/figma-chat-builder/commit/e8d2a3bec479b2f7b4baad8e526f02559853d3bc))
+- remove dead code, unused deps, and reorganize project structure ([7119f16](https://github.com/pdugan20/figma-chat-builder/commit/7119f16184c4a5f39f3859e046e0cacf710c203a))
+- replace hardcoded dev flags with build-time env injection ([9498a62](https://github.com/pdugan20/figma-chat-builder/commit/9498a62deeb1ca10e5e649eeeb628844325b87af))
+- **services:** create APIService (Sprint 3) ([68c28ac](https://github.com/pdugan20/figma-chat-builder/commit/68c28acf09d55b1682470a38353d070323b1f164))
+- **services:** create ChatGenerationService (Sprint 4) ([317a41e](https://github.com/pdugan20/figma-chat-builder/commit/317a41e1503813954ca409da965f7af969a03864))
+- **services:** create PluginMessengerService and context (Sprint 2) ([f3291a1](https://github.com/pdugan20/figma-chat-builder/commit/f3291a1470892fe899d9319207a042741033781b))
+- **services:** create ValidationService and LoadingStateManager (Sprint 1) ([65a55b1](https://github.com/pdugan20/figma-chat-builder/commit/65a55b18a97063efe065bf54747cc30defd2aec3))
 
 ### Documentation
 
-* finalize dependency upgrade tracker ([9b4223a](https://github.com/pdugan20/chat-builder-plugin/commit/9b4223a0ede660c73a54fdff81457f7b20e187ce))
-* finalize dependency upgrade tracker ([0a7c1f9](https://github.com/pdugan20/chat-builder-plugin/commit/0a7c1f9690feb69bbcbcdefa41d92067cc028db0))
-* reorganize docs folder and add dependency upgrade tracker ([8eba182](https://github.com/pdugan20/chat-builder-plugin/commit/8eba182a176990e44e3ced4a46cc424f554ee128))
-* update README badges, versions, and doc links ([c02b702](https://github.com/pdugan20/chat-builder-plugin/commit/c02b70230038cbbc15788b8b3b53f6dbb1238be0))
+- bump Node prerequisite v20+ to v22+ ([#60](https://github.com/pdugan20/figma-chat-builder/issues/60)) ([66796b6](https://github.com/pdugan20/figma-chat-builder/commit/66796b6cddf73e6aba5512ee84acc0a119b06bd1))
+- clean up README - remove test coverage details and simplify title ([b937d98](https://github.com/pdugan20/figma-chat-builder/commit/b937d98f0fdadfab4a421f214f1771885dc3930a))
+- consolidate documentation and fix inaccuracies ([#33](https://github.com/pdugan20/figma-chat-builder/issues/33)) ([63ba850](https://github.com/pdugan20/figma-chat-builder/commit/63ba850a402d59ad80d300ebd0be7dd6ad79599b))
+- drop tech stack section ([7f46e55](https://github.com/pdugan20/figma-chat-builder/commit/7f46e558a237ec7da81701a30b9d04a9f4788f37))
+- enhance documentation with badges and contribution guidelines ([a69cd4a](https://github.com/pdugan20/figma-chat-builder/commit/a69cd4af085697e009d416b886dd268c424d6182))
+- finalize dependency upgrade tracker ([9b4223a](https://github.com/pdugan20/figma-chat-builder/commit/9b4223a0ede660c73a54fdff81457f7b20e187ce))
+- finalize dependency upgrade tracker ([0a7c1f9](https://github.com/pdugan20/figma-chat-builder/commit/0a7c1f9690feb69bbcbcdefa41d92067cc028db0))
+- fold Features into intro prose ([#61](https://github.com/pdugan20/figma-chat-builder/issues/61)) ([a95ccdb](https://github.com/pdugan20/figma-chat-builder/commit/a95ccdb1991a87b04e0c18a2c69db7e085d38229))
+- remove extra license section from README ([c50bf97](https://github.com/pdugan20/figma-chat-builder/commit/c50bf97d525976e06c4ba1725e1c0f51498420a7))
+- rename repo to figma-chat-builder, title 'Chat Builder Figma Plugin' ([0b1c17e](https://github.com/pdugan20/figma-chat-builder/commit/0b1c17e199acfed40c50090bbd03997da469fded))
+- reorganize docs folder and add dependency upgrade tracker ([8eba182](https://github.com/pdugan20/figma-chat-builder/commit/8eba182a176990e44e3ced4a46cc424f554ee128))
+- replace end-to-end flow prose with mermaid architecture diagram ([aabbdf0](https://github.com/pdugan20/figma-chat-builder/commit/aabbdf0a9906efb0e662e4831048f793aff223a8))
+- restore clean concise README ([c6a747c](https://github.com/pdugan20/figma-chat-builder/commit/c6a747c4f8278524bfdb2a1cdec74e5db4f040f7))
+- title README 'iMessage Chat Builder for Figma' ([98c6c62](https://github.com/pdugan20/figma-chat-builder/commit/98c6c627c4227712aac8c3f70b8466642f1005d6))
+- trim README badges to CI, Release, Figma Community, License ([4caa534](https://github.com/pdugan20/figma-chat-builder/commit/4caa5340a1b5db24b3606a0d9a81ed07f0d308ab))
+- update README badges, versions, and doc links ([c02b702](https://github.com/pdugan20/figma-chat-builder/commit/c02b70230038cbbc15788b8b3b53f6dbb1238be0))
 
-## [1.1.0](https://github.com/pdugan20/chat-builder-plugin/compare/imessage-chat-builder-v1.0.7...imessage-chat-builder-v1.1.0) (2026-03-05)
-
+## [1.2.0](https://github.com/pdugan20/figma-chat-builder/compare/v1.1.0...v1.2.0) (2026-03-05)
 
 ### Features
 
-* upgrade to Claude Sonnet 4.6 and add automated release pipeline ([2405136](https://github.com/pdugan20/chat-builder-plugin/commit/24051365b4855b32e31e869fbab803a729feb390))
+- **api:** improve prompt engineering and fix parameter threading ([33f83ba](https://github.com/pdugan20/figma-chat-builder/commit/33f83bac25b82d74237b4835b1373840070d3136))
+- **deps:** upgrade to React 19 and testing-library 16 ([fbd524b](https://github.com/pdugan20/figma-chat-builder/commit/fbd524bd0363ba9e8c733bc6415f61b3d6d26469))
+- **deps:** upgrade to React 19 and testing-library 16 ([19d5754](https://github.com/pdugan20/figma-chat-builder/commit/19d5754c1a7a0515d94bc18a750dbb299b8f1560))
 
+### Refactoring
+
+- **lint:** migrate to ESLint 9 flat config ([3c74303](https://github.com/pdugan20/figma-chat-builder/commit/3c74303d79b78e2ac952ce6db8f2db267068cf48))
+- **lint:** migrate to ESLint 9 flat config ([e8d2a3b](https://github.com/pdugan20/figma-chat-builder/commit/e8d2a3bec479b2f7b4baad8e526f02559853d3bc))
+
+### Documentation
+
+- finalize dependency upgrade tracker ([9b4223a](https://github.com/pdugan20/figma-chat-builder/commit/9b4223a0ede660c73a54fdff81457f7b20e187ce))
+- finalize dependency upgrade tracker ([0a7c1f9](https://github.com/pdugan20/figma-chat-builder/commit/0a7c1f9690feb69bbcbcdefa41d92067cc028db0))
+- reorganize docs folder and add dependency upgrade tracker ([8eba182](https://github.com/pdugan20/figma-chat-builder/commit/8eba182a176990e44e3ced4a46cc424f554ee128))
+- update README badges, versions, and doc links ([c02b702](https://github.com/pdugan20/figma-chat-builder/commit/c02b70230038cbbc15788b8b3b53f6dbb1238be0))
+
+## [1.1.0](https://github.com/pdugan20/figma-chat-builder/releases/tag/v1.1.0) (2026-03-05)
+
+### Features
+
+- upgrade to Claude Sonnet 4.6 and add automated release pipeline ([2405136](https://github.com/pdugan20/figma-chat-builder/commit/24051365b4855b32e31e869fbab803a729feb390))
 
 ### Bug Fixes
 
-* resolve API response parsing and restore loading overlay ([08a9ec2](https://github.com/pdugan20/chat-builder-plugin/commit/08a9ec2b813f96a110ca1e1fed5fc7844ef604f1))
-* resolve double ellipsis, error handling mismatch, and env flag injection ([7193ffd](https://github.com/pdugan20/chat-builder-plugin/commit/7193ffd1fc2df5ef21a7cb525aa38f0005234df3))
-
+- resolve API response parsing and restore loading overlay ([08a9ec2](https://github.com/pdugan20/figma-chat-builder/commit/08a9ec2b813f96a110ca1e1fed5fc7844ef604f1))
+- resolve double ellipsis, error handling mismatch, and env flag injection ([7193ffd](https://github.com/pdugan20/figma-chat-builder/commit/7193ffd1fc2df5ef21a7cb525aa38f0005234df3))
 
 ### Refactoring
 
-* **hooks:** refactor use-chat-generation to use services (Sprint 5) ([301af9f](https://github.com/pdugan20/chat-builder-plugin/commit/301af9f555cfb103eca34bd3a6cab47be49bf5ae))
-* remove dead code, unused deps, and reorganize project structure ([7119f16](https://github.com/pdugan20/chat-builder-plugin/commit/7119f16184c4a5f39f3859e046e0cacf710c203a))
-* replace hardcoded dev flags with build-time env injection ([9498a62](https://github.com/pdugan20/chat-builder-plugin/commit/9498a62deeb1ca10e5e649eeeb628844325b87af))
-* **services:** create APIService (Sprint 3) ([68c28ac](https://github.com/pdugan20/chat-builder-plugin/commit/68c28acf09d55b1682470a38353d070323b1f164))
-* **services:** create ChatGenerationService (Sprint 4) ([317a41e](https://github.com/pdugan20/chat-builder-plugin/commit/317a41e1503813954ca409da965f7af969a03864))
-* **services:** create PluginMessengerService and context (Sprint 2) ([f3291a1](https://github.com/pdugan20/chat-builder-plugin/commit/f3291a1470892fe899d9319207a042741033781b))
-* **services:** create ValidationService and LoadingStateManager (Sprint 1) ([65a55b1](https://github.com/pdugan20/chat-builder-plugin/commit/65a55b18a97063efe065bf54747cc30defd2aec3))
-
+- **hooks:** refactor use-chat-generation to use services (Sprint 5) ([301af9f](https://github.com/pdugan20/figma-chat-builder/commit/301af9f555cfb103eca34bd3a6cab47be49bf5ae))
+- remove dead code, unused deps, and reorganize project structure ([7119f16](https://github.com/pdugan20/figma-chat-builder/commit/7119f16184c4a5f39f3859e046e0cacf710c203a))
+- replace hardcoded dev flags with build-time env injection ([9498a62](https://github.com/pdugan20/figma-chat-builder/commit/9498a62deeb1ca10e5e649eeeb628844325b87af))
+- **services:** create APIService (Sprint 3) ([68c28ac](https://github.com/pdugan20/figma-chat-builder/commit/68c28acf09d55b1682470a38353d070323b1f164))
+- **services:** create ChatGenerationService (Sprint 4) ([317a41e](https://github.com/pdugan20/figma-chat-builder/commit/317a41e1503813954ca409da965f7af969a03864))
+- **services:** create PluginMessengerService and context (Sprint 2) ([f3291a1](https://github.com/pdugan20/figma-chat-builder/commit/f3291a1470892fe899d9319207a042741033781b))
+- **services:** create ValidationService and LoadingStateManager (Sprint 1) ([65a55b1](https://github.com/pdugan20/figma-chat-builder/commit/65a55b18a97063efe065bf54747cc30defd2aec3))
 
 ### Documentation
 
-* clean up README - remove test coverage details and simplify title ([b937d98](https://github.com/pdugan20/chat-builder-plugin/commit/b937d98f0fdadfab4a421f214f1771885dc3930a))
-* enhance documentation with badges and contribution guidelines ([a69cd4a](https://github.com/pdugan20/chat-builder-plugin/commit/a69cd4af085697e009d416b886dd268c424d6182))
-* remove extra license section from README ([c50bf97](https://github.com/pdugan20/chat-builder-plugin/commit/c50bf97d525976e06c4ba1725e1c0f51498420a7))
-* restore clean concise README ([c6a747c](https://github.com/pdugan20/chat-builder-plugin/commit/c6a747c4f8278524bfdb2a1cdec74e5db4f040f7))
+- clean up README - remove test coverage details and simplify title ([b937d98](https://github.com/pdugan20/figma-chat-builder/commit/b937d98f0fdadfab4a421f214f1771885dc3930a))
+- enhance documentation with badges and contribution guidelines ([a69cd4a](https://github.com/pdugan20/figma-chat-builder/commit/a69cd4af085697e009d416b886dd268c424d6182))
+- remove extra license section from README ([c50bf97](https://github.com/pdugan20/figma-chat-builder/commit/c50bf97d525976e06c4ba1725e1c0f51498420a7))
+- restore clean concise README ([c6a747c](https://github.com/pdugan20/figma-chat-builder/commit/c6a747c4f8278524bfdb2a1cdec74e5db4f040f7))
 
 ## Changelog
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## What changed

- configure Release Please to emit plain `vX.Y.Z` tags for the single package
- remove the stale comment claiming the workflow is pinned to Release Please v4
- repair historical changelog links after the repository and tag naming changes

## Why

The v1.3.0 release inherited the package component name and was published as `imessage-chat-builder-v1.3.0` with the title `imessage-chat-builder: v1.3.0`. Other single-package repositories in this account explicitly disable component names in tags.

## Impact

Future releases will use the established `vX.Y.Z` tag and title convention. The existing v1.3.0 release will be renamed after this PR lands.

## Verification

- `npm run style:write`
- `npm run lint:fix`
- `npx tsc --noEmit --skipLibCheck`
- `npm run lint:md`
- `npm run build`
- `npm test -- --runInBand` (88 tests)
